### PR TITLE
chore: release v0.2.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,17 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+## [0.2.0](https://github.com/jettify/uf-crsf/compare/v0.1.0...v0.2.0) - 2025-08-28
+
+### Added
+
+- Add experimental crossfire commands ([#39](https://github.com/jettify/uf-crsf/issues/39))
 ## [0.1.0] - 2025-08-27
 
 ### Features

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -307,7 +307,7 @@ dependencies = [
 
 [[package]]
 name = "uf-crsf"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "crc",
  "defmt",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "uf-crsf"
-version = "0.1.0"
+version = "0.2.0"
 edition = "2021"
 
 description = "A `no_std` Rust library for parsing the TBS Crossfire protocol, designed for embedded environments"


### PR DESCRIPTION



## 🤖 New release

* `uf-crsf`: 0.1.0 -> 0.2.0 (⚠ API breaking changes)

### ⚠ `uf-crsf` breaking changes

```text
--- failure enum_variant_added: enum variant added on exhaustive enum ---

Description:
A publicly-visible enum without #[non_exhaustive] has a new variant.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#enum-variant-new
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.43.0/src/lints/enum_variant_added.ron

Failed in:
  variant Packet:Commands in /tmp/.tmpoNAvvA/uf-crsf/src/packets/mod.rs:113
  variant Packet:Commands in /tmp/.tmpoNAvvA/uf-crsf/src/packets/mod.rs:113
```

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.2.0](https://github.com/jettify/uf-crsf/compare/v0.1.0...v0.2.0) - 2025-08-28

### Added

- Add experimental crossfire commands ([#39](https://github.com/jettify/uf-crsf/issues/39))
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).