### PR TITLE
chore: release v0.2.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.2.1](https://github.com/jettify/uf-crsf/compare/v0.2.0...v0.2.1) - 2025-09-04
+
+### Fixed
+
+- Make library heapless 0.8 and 0.9 compatible. ([#45](https://github.com/jettify/uf-crsf/issues/45))
+- Adds comprehensive bounds checks to all `write_to` methods. ([#43](https://github.com/jettify/uf-crsf/issues/43))
+
+### Other
+
+- Fixed homepage links in Cargo.toml, update README with badges. ([#44](https://github.com/jettify/uf-crsf/issues/44))
+- Add full text of Apache license. ([#41](https://github.com/jettify/uf-crsf/issues/41))
+
 ## [0.2.0](https://github.com/jettify/uf-crsf/compare/v0.1.0...v0.2.0) - 2025-08-28
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -307,7 +307,7 @@ dependencies = [
 
 [[package]]
 name = "uf-crsf"
-version = "0.2.0"
+version = "0.2.1"
 dependencies = [
  "crc",
  "defmt",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "uf-crsf"
-version = "0.2.0"
+version = "0.2.1"
 edition = "2021"
 
 description = "A `no_std` Rust library for parsing the TBS Crossfire protocol, designed for embedded environments"


### PR DESCRIPTION



## 🤖 New release

* `uf-crsf`: 0.2.0 -> 0.2.1 (✓ API compatible changes)

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.2.1](https://github.com/jettify/uf-crsf/compare/v0.2.0...v0.2.1) - 2025-09-04

### Fixed

- Make library heapless 0.8 and 0.9 compatible. ([#45](https://github.com/jettify/uf-crsf/issues/45))
- Adds comprehensive bounds checks to all `write_to` methods. ([#43](https://github.com/jettify/uf-crsf/issues/43))

### Other

- Fixed homepage links in Cargo.toml, update README with badges. ([#44](https://github.com/jettify/uf-crsf/issues/44))
- Add full text of Apache license. ([#41](https://github.com/jettify/uf-crsf/issues/41))
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).