### PR TITLE
chore: release v0.3.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.3.0](https://github.com/jettify/uf-crsf/compare/v0.2.1...v0.3.0) - 2025-09-06
+
+### Fixed
+
+- [**breaking**] Remove heapless from public field to ensure better compatibility with downstream users. ([#47](https://github.com/jettify/uf-crsf/issues/47))
+
+### Other
+
+- Indicate implemented packets in readme. ([#51](https://github.com/jettify/uf-crsf/issues/51))
+- Bump version of heapless. ([#50](https://github.com/jettify/uf-crsf/issues/50))
+- Run security audit on schedule instead on each PR. ([#46](https://github.com/jettify/uf-crsf/issues/46))
+- [**breaking**] Remove heapless::String from public API. ([#48](https://github.com/jettify/uf-crsf/issues/48))
+
 ## [0.2.1](https://github.com/jettify/uf-crsf/compare/v0.2.0...v0.2.1) - 2025-09-04
 
 ### Fixed

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -307,7 +307,7 @@ dependencies = [
 
 [[package]]
 name = "uf-crsf"
-version = "0.2.1"
+version = "0.3.0"
 dependencies = [
  "crc",
  "defmt",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "uf-crsf"
-version = "0.2.1"
+version = "0.3.0"
 edition = "2021"
 
 description = "A `no_std` Rust library for parsing the TBS Crossfire protocol, designed for embedded environments"


### PR DESCRIPTION



## 🤖 New release

* `uf-crsf`: 0.2.1 -> 0.3.0 (⚠ API breaking changes)

### ⚠ `uf-crsf` breaking changes

```text
--- failure struct_pub_field_missing: pub struct's pub field removed or renamed ---

Description:
A publicly-visible struct has at least one public field that is no longer available under its prior name. It may have been renamed or removed entirely.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#item-remove
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.43.0/src/lints/struct_pub_field_missing.ron

Failed in:
  field data of struct MavlinkEnvelope, previously in file /tmp/.tmp6hJuHD/uf-crsf/src/packets/mavlink_envelope.rs:18
  field rpm_values of struct Rpm, previously in file /tmp/.tmp6hJuHD/uf-crsf/src/packets/rpm.rs:17
  field voltage_values of struct Voltages, previously in file /tmp/.tmp6hJuHD/uf-crsf/src/packets/voltages.rs:15
  field flight_mode of struct FlightMode, previously in file /tmp/.tmp6hJuHD/uf-crsf/src/packets/flight_mode.rs:14
  field temperatures of struct Temp, previously in file /tmp/.tmp6hJuHD/uf-crsf/src/packets/temp.rs:17
  field device_name of struct DeviceInformation, previously in file /tmp/.tmp6hJuHD/uf-crsf/src/packets/device_information.rs:14

--- failure struct_pub_field_now_doc_hidden: pub struct field is now #[doc(hidden)] ---

Description:
A pub field of a pub struct is now marked #[doc(hidden)] and is no longer part of the public API.
        ref: https://doc.rust-lang.org/rustdoc/write-documentation/the-doc-attribute.html#hidden
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.43.0/src/lints/struct_pub_field_now_doc_hidden.ron

Failed in:
  field MavlinkEnvelope.data in file /tmp/.tmpegullM/uf-crsf/src/packets/mavlink_envelope.rs:12
  field Rpm.rpm_values in file /tmp/.tmpegullM/uf-crsf/src/packets/rpm.rs:12
  field Voltages.voltage_values in file /tmp/.tmpegullM/uf-crsf/src/packets/voltages.rs:11
  field FlightMode.flight_mode in file /tmp/.tmpegullM/uf-crsf/src/packets/flight_mode.rs:12
  field Temp.temperatures in file /tmp/.tmpegullM/uf-crsf/src/packets/temp.rs:12
  field DeviceInformation.device_name in file /tmp/.tmpegullM/uf-crsf/src/packets/device_information.rs:12
```

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.3.0](https://github.com/jettify/uf-crsf/compare/v0.2.1...v0.3.0) - 2025-09-06

### Fixed

- [**breaking**] Remove heapless from public field to ensure better compatibility with downstream users. ([#47](https://github.com/jettify/uf-crsf/issues/47))

### Other

- Indicate implemented packets in readme. ([#51](https://github.com/jettify/uf-crsf/issues/51))
- Bump version of heapless. ([#50](https://github.com/jettify/uf-crsf/issues/50))
- Run security audit on schedule instead on each PR. ([#46](https://github.com/jettify/uf-crsf/issues/46))
- [**breaking**] Remove heapless::String from public API. ([#48](https://github.com/jettify/uf-crsf/issues/48))
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).