### PR TITLE
chore: release v0.6.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,24 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.6.0](https://github.com/jettify/uf-crsf/compare/v0.5.0...v0.6.0) - 2026-04-22
+
+### Added
+
+- Implement gyro, baro and mag packets. ([#94](https://github.com/jettify/uf-crsf/issues/94))
+
+### Fixed
+
+- Fix unrecoverable parser desync. ([#96](https://github.com/jettify/uf-crsf/issues/96))
+
+### Other
+
+- Remove unwrap from device information packet.
+- Add test coverage for new constructor. ([#93](https://github.com/jettify/uf-crsf/issues/93))
+- Specify msrv. ([#92](https://github.com/jettify/uf-crsf/issues/92))
+- Use just commands in the github actions. ([#88](https://github.com/jettify/uf-crsf/issues/88))
+- Add blocking io example. ([#90](https://github.com/jettify/uf-crsf/issues/90))
+
 ## [0.5.0](https://github.com/jettify/uf-crsf/compare/v0.4.0...v0.5.0) - 2025-12-24
 
 ### Fixed

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -618,7 +618,7 @@ dependencies = [
 
 [[package]]
 name = "uf-crsf"
-version = "0.5.0"
+version = "0.6.0"
 dependencies = [
  "crc",
  "defmt",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "uf-crsf"
-version = "0.5.0"
+version = "0.6.0"
 edition = "2021"
 rust-version = "1.87.0"
 


### PR DESCRIPTION



## 🤖 New release

* `uf-crsf`: 0.5.0 -> 0.6.0 (⚠ API breaking changes)

### ⚠ `uf-crsf` breaking changes

```text
--- failure enum_variant_added: enum variant added on exhaustive enum ---

Description:
A publicly-visible enum without #[non_exhaustive] has a new variant.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#enum-variant-new
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.46.0/src/lints/enum_variant_added.ron

Failed in:
  variant Packet:Barometer in /tmp/.tmpPT7USp/uf-crsf/src/packets/mod.rs:107
  variant Packet:Magnetometer in /tmp/.tmpPT7USp/uf-crsf/src/packets/mod.rs:108
  variant Packet:AccelGyro in /tmp/.tmpPT7USp/uf-crsf/src/packets/mod.rs:109
  variant Packet:Barometer in /tmp/.tmpPT7USp/uf-crsf/src/packets/mod.rs:107
  variant Packet:Magnetometer in /tmp/.tmpPT7USp/uf-crsf/src/packets/mod.rs:108
  variant Packet:AccelGyro in /tmp/.tmpPT7USp/uf-crsf/src/packets/mod.rs:109
```

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.6.0](https://github.com/jettify/uf-crsf/compare/v0.5.0...v0.6.0) - 2026-04-22

### Added

- Implement gyro, baro and mag packets. ([#94](https://github.com/jettify/uf-crsf/issues/94))

### Fixed

- Fix unrecoverable parser desync. ([#96](https://github.com/jettify/uf-crsf/issues/96))

### Other

- Remove unwrap from device information packet.
- Add test coverage for new constructor. ([#93](https://github.com/jettify/uf-crsf/issues/93))
- Specify msrv. ([#92](https://github.com/jettify/uf-crsf/issues/92))
- Use just commands in the github actions. ([#88](https://github.com/jettify/uf-crsf/issues/88))
- Add blocking io example. ([#90](https://github.com/jettify/uf-crsf/issues/90))
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).