### PR TITLE
chore: release v0.6.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.6.1](https://github.com/jettify/uf-crsf/compare/v0.6.0...v0.6.1) - 2026-05-19
+
+### Fixed
+
+- Fix panic for rpm, temp and voltagess in case too many values.
+- Fix paning in device ping packet.
+
+### Other
+
+- Remove more unwrap usaage. ([#98](https://github.com/jettify/uf-crsf/issues/98))
+- Avoid using unwrap in gps packets.
+
 ## [0.6.0](https://github.com/jettify/uf-crsf/compare/v0.5.0...v0.6.0) - 2026-04-22
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -618,7 +618,7 @@ dependencies = [
 
 [[package]]
 name = "uf-crsf"
-version = "0.6.0"
+version = "0.6.1"
 dependencies = [
  "crc",
  "defmt",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "uf-crsf"
-version = "0.6.0"
+version = "0.6.1"
 edition = "2021"
 rust-version = "1.87.0"
 


### PR DESCRIPTION



## 🤖 New release

* `uf-crsf`: 0.6.0 -> 0.6.1 (✓ API compatible changes)

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.6.1](https://github.com/jettify/uf-crsf/compare/v0.6.0...v0.6.1) - 2026-05-19

### Fixed

- Fix panic for rpm, temp and voltagess in case too many values.
- Fix paning in device ping packet.

### Other

- Remove more unwrap usaage. ([#98](https://github.com/jettify/uf-crsf/issues/98))
- Avoid using unwrap in gps packets.
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).